### PR TITLE
Visual updates:

### DIFF
--- a/addon/globalPlugins/tonysEnhancements/__init__.py
+++ b/addon/globalPlugins/tonysEnhancements/__init__.py
@@ -204,24 +204,29 @@ reloadLangMap()
 updatePriority()
 class MultilineEditTextDialog(wx.Dialog):
     def __init__(self, parent, text, title_string, onTextComplete):
-        # Translators: Title of calibration dialog
         super(MultilineEditTextDialog, self).__init__(parent, title=title_string)
         self.text = text
         self.onTextComplete = onTextComplete
         mainSizer = wx.BoxSizer(wx.VERTICAL)
         sHelper = gui.guiHelper.BoxSizerHelper(self, orientation=wx.VERTICAL)
 
-        self.textCtrl = wx.TextCtrl(self, style=wx.TE_MULTILINE)
+        self.textCtrl = wx.TextCtrl(self, size=(-1, 150), style=wx.TE_MULTILINE|wx.TE_DONTWRAP)
         self.textCtrl.Bind(wx.EVT_CHAR, self.onChar)
         self.Bind(wx.EVT_CHAR_HOOK, self.OnKeyUP)
-        sHelper.addItem(self.textCtrl)
+        sHelper.addItem(self.textCtrl, flag=wx.EXPAND)
         self.textCtrl.SetValue(text)
-        self.SetFocus()
-        #self.Maximize(True)
-        self.OkButton = sHelper.addItem (wx.Button (self, label = _('OK')))
+        
+        buttonGroup = gui.guiHelper.ButtonHelper(wx.HORIZONTAL)
+        self.OkButton = buttonGroup.addButton(self, label=_('OK'))
         self.OkButton.Bind(wx.EVT_BUTTON, self.onOk)
-        self.cancelButton = sHelper.addItem (wx.Button (self, label = _('Cancel')))
+        self.cancelButton = buttonGroup.addButton(self, label=_('Cancel'))
         self.cancelButton.Bind(wx.EVT_BUTTON, self.onCancel)
+        sHelper.addItem(buttonGroup)
+        
+        mainSizer.Add(sHelper.sizer, border=10, flag=wx.ALL|wx.EXPAND, proportion=1)
+        self.SetSizer(mainSizer)
+        
+        self.SetFocus()
 
     def onChar(self, event):
         control = event.ControlDown()
@@ -427,7 +432,7 @@ class SettingsDialog(SettingsPanel):
         self.popupLangMap(text=self.langMap)
 
     def popupLangMap(self, text):
-        title = _('Edit language amp')
+        title = _('Edit language map')
         gui.mainFrame.prePopup()
         dialog = MultilineEditTextDialog(self,
             text=text,

--- a/addon/globalPlugins/tonysEnhancements/__init__.py
+++ b/addon/globalPlugins/tonysEnhancements/__init__.py
@@ -362,13 +362,16 @@ class SettingsDialog(SettingsPanel):
         self.langMapButton = sHelper.addItem (wx.Button (self, label = label))
         self.langMapButton.Bind(wx.EVT_BUTTON, self.onLangMapClick)
       # QuickSearch regexp text edit
-        self.quickSearchEdit = gui.guiHelper.LabeledControlHelper(self, _("QuickSearch1 regexp (assigned to PrintScreen)"), wx.TextCtrl).control
+        label = _("QuickSearch1 regexp (assigned to PrintScreen)")
+        self.quickSearchEdit = sHelper.addLabeledControl(label, wx.TextCtrl)
         self.quickSearchEdit.Value = getConfig("quickSearch1")
       # QuickSearch2 regexp text edit
-        self.quickSearch2Edit = gui.guiHelper.LabeledControlHelper(self, _("QuickSearch2 regexp (assigned to ScrollLock))"), wx.TextCtrl).control
+        label = _("QuickSearch2 regexp (assigned to ScrollLock))")
+        self.quickSearch2Edit = sHelper.addLabeledControl(label, wx.TextCtrl)
         self.quickSearch2Edit.Value = getConfig("quickSearch2")
       # QuickSearch3 regexp text edit
-        self.quickSearch3Edit = gui.guiHelper.LabeledControlHelper(self, _("QuickSearch3 regexp (assigned to Pause)"), wx.TextCtrl).control
+        label = _("QuickSearch3 regexp (assigned to Pause)")
+        self.quickSearch3Edit = sHelper.addLabeledControl(label, wx.TextCtrl)
         self.quickSearch3Edit.Value = getConfig("quickSearch3")
       # checkbox block scroll lock
         # Translators: Checkbox for blocking scroll lock

--- a/style.css
+++ b/style.css
@@ -1,8 +1,6 @@
 ﻿@charset "utf-8";
 body { 
 font-family : Verdana, Arial, Helvetica, Sans-serif;
-color : #FFFFFF;
-background-color : #000000;
 line-height: 1.2em;
 } 
 h1, h2 {text-align: center}
@@ -26,5 +24,3 @@ a { text-decoration : underline;
 text-decoration : none; 
 }
 a:focus, a:hover {outline: solid}
-:link {color: #0000FF;
-background-color: #FFFFFF}


### PR DESCRIPTION
Hi Tony

Here are three visual modifications in the add-on.

1. GUI settings panel: Quick search regexp controls are now located correctly.
Initially they were all located and overlapping each other in the top left corner of the panel.

2. Modify style.css to be aligned with last one in the add-on template

3. MultilineEditTextDialog layout
The layout of this dialog was visually totally buggy. The OK and cancel buttons were hidden by the edit area because all were located at the top left corner. And the edit area was very little.
The following modifications have been made:
   * put the two buttons horizontally below the edit control
   * Increase the size of the edit control
   * Do not allow text wrap in the edit control in order to avoid line splitting in the dynamic keystroke or language ma^p tables
