### PR TITLE
The name of scripts dynamically created can now appear in the log during input help.

### DIFF
--- a/addon/globalPlugins/tonysEnhancements/__init__.py
+++ b/addon/globalPlugins/tonysEnhancements/__init__.py
@@ -1584,6 +1584,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
         cls = documentBase.DocumentWithTableNavigation
         funcName = "script_%s" % scriptName
         script = lambda self,gesture: function(self, gesture, *args, **kwargs)
+        script.__name__ = funcName
         script.__doc__ = doc
         script.category = self.scriptCategory
         setattr(cls, funcName, script)


### PR DESCRIPTION
## Issue
### STR
* Activate input help (NVDA+1)
* Press NVDA+alt+2
* Deactivate input help
* Look at the log when the script was executed.

### Actual result
In the log, the script's name is missing.
```
INFO - inputCore.InputManager._handleInputHelp (14:32:20.742) - MainThread (20148):
Input help: gesture kb(desktop):NVDA+alt+2, bound to script >
```

### Expected result
```
INFO - inputCore.InputManager._handleInputHelp (14:52:32.378) - MainThread (17444):
Input help: gesture kb(desktop):NVDA+alt+2, bound to script jumpToRow2 on documentBase.DocumentWithTableNavigation
```

## Fix
Added the name to the script created dynamically.

## Known issue:
The script is then indicated to be on on `documentBase.DocumentWithTableNavigation`. This is true but one may not use this information to find the script in the source code of this class since the script is bound dynamically to this class.

However, a way to find where the script is defined is then to type this in the console:
```
>>> import documentBase
>>> documentBase.DocumentWithTableNavigation.script_jumpToRow2
<function GlobalPlugin.injectTableFunction.<locals>.<lambda> at 0x04832A50>



```