### PR TITLE
Restore table functions for NVDA 2022.4 and above

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # nvda-tonys-enhancements
 This add-on contains a number of small improvements to NVDA screenreader, each of them too small to deserve a separate add-on.
 
-This add-on is only compatible with NVDA versions 2019.3 and above.
+This add-on is only compatible with NVDA versions 2022.4 and above.
 
 ## Downloads
 

--- a/buildVars.py
+++ b/buildVars.py
@@ -27,9 +27,9 @@ addon_info = {
 	# Documentation file name
 	"addon_docFileName" : "readme.html",
 	# Minimum NVDA version supported (e.g. "2018.3")
-	"addon_minimumNVDAVersion" : "2019.3.0",
+	"addon_minimumNVDAVersion" : "2022.4.0",
 	# Last NVDA version supported/tested (e.g. "2018.4", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion" : "2022.1.0",
+	"addon_lastTestedNVDAVersion" : "2022.4.0",
 	# Add-on update channel (default is stable or None)
 	"addon_updateChannel" : None,
 }


### PR DESCRIPTION
Hello Tony,
Here are modifications that I have made regarding table functions for NVDA 2022.4 and above so that I can use the add-on. If you are interested, feel free to take it.
If you are not interested, e.g. because you want to make a code that keeps compatibility with older NVDA, no worry.

### Link to issue
Fixes #16 
### Issue description
Table related commands of this add-on are failing with newer versions of NVDA (2022.2 and above)

### Solution
Use the new signature of the functions introduced in NVDA 2022.2 and 2022.4.

### Limitations
* Since change have been introduced with table nav functions in NVDA 2022.2 and 2022.4, this PR makes the table navigation and copy functions compatible with NVDA 2022.4. I did not bother to make it compatible with 2022.2 or 2022.3, neither with older releases. If you plan to keep the current compatibility with NVDA 2019.3 and above, you will have to work on it; I do not plan to provide you such proposal.
* As it was already the case, table navigation functions still use private core functions. Thus, this add-on may be broken wiht non-API-breaking releases of NVDA in case such private functions are modified. I guess you are well aware of it and accept this risk. Moreover, now that they are recent and that you have provided the most asked table functions, we can hope that they will not change so soon.

### Additional comments
* Some functions/features of this add-on seem quite useless now that they have been introduced in NVDA's core: table navigation to edge and say all by row or column. Maybe you want to keep them in the add-on since some of them are slightly different from those of NVDA (cursor moving or not during full column or row reading). If you plan to remove them, I can do it in this PR or in another one. Just let me know.
* The table nav functions provided in this PR are compatible with NVDA 2023.1. However, since I do not use all the features of this add-on I have not updated the compatibility flag in this PR. Moreover, it seems to me that the command to increase or decrease the volume in NVDA is not working with 2023.1; I do not know if it is something new or not.




