### PR TITLE
Added a check to ensure that the `gesture` object has the `vkCode` attribute before accessing it, preventing errors due to missing attributes.

### DIFF
--- a/addon/globalPlugins/tonysEnhancements/__init__.py
+++ b/addon/globalPlugins/tonysEnhancements/__init__.py
@@ -1095,21 +1095,22 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
         global gestureCounter, editorMovingCaret, performingShiftGesture
         gestureCounter += 1
         editorMovingCaret = False
-        if (
-            getConfig("blockDoubleInsert")  and
-            gesture.vkCode == winUser.VK_INSERT and
-            not gesture.isNVDAModifierKey
-        ):
-            tones.beep(500, 50)
-            return
-        if (
-            getConfig("blockDoubleCaps")  and
-            gesture.vkCode == winUser.VK_CAPITAL and
-            not gesture.isNVDAModifierKey
-        ):
-            tones.beep(500, 50)
-            return
-
+        # Check if gesture has the vkCode attribute
+        if hasattr(gesture, 'vkCode'):
+            if (
+                getConfig("blockDoubleInsert")  and
+                gesture.vkCode == winUser.VK_INSERT and
+                not gesture.isNVDAModifierKey
+            ):
+                tones.beep(500, 50)
+                return
+            if (
+                getConfig("blockDoubleCaps")  and
+                gesture.vkCode == winUser.VK_CAPITAL and
+                not gesture.isNVDAModifierKey
+            ):
+                tones.beep(500, 50)
+                return
         kb = gesture.identifiers
         if len(kb) == 0:
             pass


### PR DESCRIPTION
### Related Issue
Fixed #3 
From what I've investigated, this issue also prevents touchscreen users from interacting with the touchscreen.
### Description
Added a check to ensure that the `gesture` object has the `vkCode` attribute before accessing it, preventing errors due to missing attributes.

### Changes Made
- Added a conditional check `if hasattr(gesture, 'vkCode'):` before accessing `gesture.vkCode` to avoid attribute errors.
- Updated the `preExecuteGesture` method to include this check.

### Context
This change is necessary to prevent exceptions when the `vkCode` attribute is missing from the `gesture` object. By adding this check, the method can safely access `gesture.vkCode` only when it is available, ensuring smooth execution without errors.

